### PR TITLE
Switch password hashing to Argon2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pyyaml
 trafaret-config==2.0.2
 trafaret==1.2.0
 yarl==1.3.0               # via aiohttp
+argon2-cffi

--- a/sqli/dao/user.py
+++ b/sqli/dao/user.py
@@ -38,4 +38,5 @@ class User(NamedTuple):
             return User.from_raw(await cur.fetchone())
 
     def check_password(self, password: str):
-        return self.pwd_hash == md5(password.encode('utf-8')).hexdigest()
+        # return self.pwd_hash == md5(password.encode('utf-8')).hexdigest()
+        return ph.verify(self.pwd_hash, password.encode('utf-8'))

--- a/sqli/dao/user.py
+++ b/sqli/dao/user.py
@@ -39,4 +39,5 @@ class User(NamedTuple):
 
     def check_password(self, password: str):
         # return self.pwd_hash == md5(password.encode('utf-8')).hexdigest()
+        ph = PasswordHasher()
         return ph.verify(self.pwd_hash, password.encode('utf-8'))

--- a/sqli/dao/user.py
+++ b/sqli/dao/user.py
@@ -2,7 +2,7 @@ from hashlib import md5
 from typing import NamedTuple, Optional
 
 from aiopg import Connection
-
+from argon2 import PasswordHasher
 
 class User(NamedTuple):
     id: int


### PR DESCRIPTION
Replaces MD5 password verification with Argon2 using the PasswordHasher class for improved security. The old MD5 check is commented out for reference.